### PR TITLE
fix crash when exit app, notifyChange will be invalid when Watchman be deleted, but uv_close is an async call and notifyChange will be access in libuv later

### DIFF
--- a/src/watchman.h
+++ b/src/watchman.h
@@ -39,7 +39,7 @@ private:
 	HANDLE refresh;
 	std::mutex activeLock;
 	std::vector<std::weak_ptr<WatchNode>> active;
-	uv_async_t notifyChange;
+	uv_async_t* notifyChange;
 	std::deque<std::shared_ptr<WatchNode>> changedNodes;
 	std::mutex changedNodesLock;
 };


### PR DESCRIPTION
fix crash when exit app, notifyChange will be invalid when Watchman be deleted, but uv_close is an async call and notifyChange will be access in libuv later
see below crash callstack crash at libuv uv__process_endgames,


 # Child-SP          RetAddr               Call Site
00 000000a7`463fc6c8 00007ffd`759da1ae     ntdll!NtDelayExecution+0x14
01 000000a7`463fc6d0 00007ff7`9454e197     KERNELBASE!SleepEx+0x9e
02 000000a7`463fc770 00007ffd`75abd827     Electron!crashpad::`anonymous namespace'::UnhandledExceptionHandler+0xe7 [D:\jenkins\workspace\RPM-Electron27-Custom-Builder\label\rcv-ce-win\electron-build\electron\src\third_party\crashpad\crashpad\client\crashpad_client_win.cc @ 186] 
03 000000a7`463fc8f0 00007ffd`77d95570     KERNELBASE!UnhandledExceptionFilter+0x1e7
04 000000a7`463fca10 00007ffd`77d7ca06     ntdll!RtlUserThreadStart$filt$0+0xa2
05 000000a7`463fca50 00007ffd`77d9247f     ntdll!_C_specific_handler+0x96
06 000000a7`463fcac0 00007ffd`77d414b4     ntdll!RtlpExecuteHandlerForException+0xf
07 000000a7`463fcaf0 00007ffd`77d90f8e     ntdll!RtlDispatchException+0x244
08 000000a7`463fd200 00007ff7`9024190b     ntdll!KiUserExceptionDispatch+0x2e
09 (Inline Function) --------`--------     Electron!uv__process_endgames+0x62 [D:\jenkins\workspace\RPM-Electron27-Custom-Builder\label\rcv-ce-win\electron-build\electron\src\third_party\electron_node\deps\uv\src\win\handle-inl.h @ 103] 
0a 000000a7`463fd930 00007ff7`9020d33b     Electron!uv_run+0x2db [D:\jenkins\workspace\RPM-Electron27-Custom-Builder\label\rcv-ce-win\electron-build\electron\src\third_party\electron_node\deps\uv\src\win\core.c @ 643] 
0b 000000a7`463fe9d0 00007ff7`9020dc9f     Electron!node::Environment::CleanupHandles+0x15b [D:\jenkins\workspace\RPM-Electron27-Custom-Builder\label\rcv-ce-win\electron-build\electron\src\third_party\electron_node\src\env.cc @ 961] 
0c 000000a7`463fea40 00007ff7`90239eba     Electron!node::Environment::RunCleanup+0x1bf [D:\jenkins\workspace\RPM-Electron27-Custom-Builder\label\rcv-ce-win\electron-build\electron\src\third_party\electron_node\src\env.cc @ 1018] 
0d 000000a7`463fece0 00007ff7`8e3c9d85     Electron!node::FreeEnvironment+0xba [D:\jenkins\workspace\RPM-Electron27-Custom-Builder\label\rcv-ce-win\electron-build\electron\src\third_party\electron_node\src\api\environment.cc @ 451] 
0e (Inline Function) --------`--------     Electron!electron::NodeBindings::CreateEnvironment::<lambda_0>::operator()+0x5a [D:\jenkins\workspace\RPM-Electron27-Custom-Builder\label\rcv-ce-win\electron-build\electron\src\electron\shell\common\node_bindings.cc @ 685] 
0f 000000a7`463fedb0 00007ff7`8e321de2     Electron!std::__Cr::__shared_ptr_pointer<node::Environment *,`lambda at ..\..\electron\shell\common\node_bindings.cc:674:22',std::__Cr::allocator<node::Environment> >::__on_zero_shared+0x85 [D:\jenkins\workspace\RPM-Electron27-Custom-Builder\label\rcv-ce-win\electron-build\electron\src\third_party\libc++\src\include\__memory\shared_ptr.h @ 261] 
10 (Inline Function) --------`--------     Electron!std::__Cr::__shared_count::__release_shared+0x1e [D:\jenkins\workspace\RPM-Electron27-Custom-Builder\label\rcv-ce-win\electron-build\electron\src\third_party\libc++\src\include\__memory\shared_ptr.h @ 172] 
11 (Inline Function) --------`--------     Electron!std::__Cr::__shared_weak_count::__release_shared+0x1e [D:\jenkins\workspace\RPM-Electron27-Custom-Builder\label\rcv-ce-win\electron-build\electron\src\third_party\libc++\src\include\__memory\shared_ptr.h @ 213] 
12 (Inline Function) --------`--------     Electron!std::__Cr::shared_ptr<node::Environment>::~shared_ptr+0x23 [D:\jenkins\workspace\RPM-Electron27-Custom-Builder\label\rcv-ce-win\electron-build\electron\src\third_party\libc++\src\include\__memory\shared_ptr.h @ 760] 
13 (Inline Function) --------`--------     Electron!std::__Cr::shared_ptr<node::Environment>::reset+0x2e [D:\jenkins\workspace\RPM-Electron27-Custom-Builder\label\rcv-ce-win\electron-build\electron\src\third_party\libc++\src\include\__memory\shared_ptr.h @ 827] 
14 000000a7`463fee10 00007ff7`8f303d64     Electron!electron::ElectronBrowserMainParts::PostMainMessageLoopRun+0x222 [D:\jenkins\workspace\RPM-Electron27-Custom-Builder\label\rcv-ce-win\electron-build\electron\src\electron\shell\browser\electron_browser_main_parts.cc @ 597] 
15 000000a7`463fef00 00007ff7`8f30599e     Electron!content::BrowserMainLoop::ShutdownThreadsAndCleanUp+0x1c4 [D:\jenkins\workspace\RPM-Electron27-Custom-Builder\label\rcv-ce-win\electron-build\electron\src\content\browser\browser_main_loop.cc @ 1128] 
16 000000a7`463ff010 00007ff7`8f300c17     Electron!content::BrowserMainRunnerImpl::Shutdown+0x8e [D:\jenkins\workspace\RPM-Electron27-Custom-Builder\label\rcv-ce-win\electron-build\electron\src\content\browser\browser_main_runner_impl.cc @ 178] 
17 000000a7`463ff0b0 00007ff7`8e4dca01     Electron!content::BrowserMain+0xf7 [D:\jenkins\workspace\RPM-Electron27-Custom-Builder\label\rcv-ce-win\electron-build\electron\src\content\browser\browser_main.cc @ 46] 
18 000000a7`463ff180 00007ff7`8e4de048     Electron!content::RunBrowserProcessMain+0xe1 [D:\jenkins\workspace\RPM-Electron27-Custom-Builder\label\rcv-ce-win\electron-build\electron\src\content\app\content_main_runner_impl.cc @ 708] 
19 000000a7`463ff2e0 00007ff7`8e4dda67     Electron!content::ContentMainRunnerImpl::RunBrowser+0x518 [D:\jenkins\workspace\RPM-Electron27-Custom-Builder\label\rcv-ce-win\electron-build\electron\src\content\app\content_main_runner_impl.cc @ 1292] 
1a 000000a7`463ff470 00007ff7`8e4d9eb4     Electron!content::ContentMainRunnerImpl::Run+0x307 [D:\jenkins\workspace\RPM-Electron27-Custom-Builder\label\rcv-ce-win\electron-build\electron\src\content\app\content_main_runner_impl.cc @ 1142] 
1b 000000a7`463ff620 00007ff7`8e4da02d     Electron!content::RunContentProcess+0x524 [D:\jenkins\workspace\RPM-Electron27-Custom-Builder\label\rcv-ce-win\electron-build\electron\src\content\app\content_main.cc @ 330] 
1c 000000a7`463ff880 00007ff7`8e21aee7     Electron!content::ContentMain+0x7d [D:\jenkins\workspace\RPM-Electron27-Custom-Builder\label\rcv-ce-win\electron-build\electron\src\content\app\content_main.cc @ 347] 
1d 000000a7`463ff910 00007ff7`9272c5e2     Electron!wWinMain+0x377 [D:\jenkins\workspace\RPM-Electron27-Custom-Builder\label\rcv-ce-win\electron-build\electron\src\electron\shell\app\electron_main_win.cc @ 239] 
1e (Inline Function) --------`--------     Electron!invoke_main+0x21 [D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl @ 118] 
1f 000000a7`463ffb20 00007ffd`76377344     Electron!__scrt_common_main_seh+0x106 [D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl @ 288] 
20 000000a7`463ffb60 00007ffd`77d426b1     KERNEL32!BaseThreadInitThunk+0x14
21 000000a7`463ffb90 00000000`00000000     ntdll!RtlUserThreadStart+0x21